### PR TITLE
fix: update ffmpeg path to avoid using /usr/local/bin and use /usr/bin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ const stop = async () => {
   }
 
   // Create a mp4 movie out of the image frames.
-  const cmd = '/usr/local/bin/ffmpeg';
+  const cmd = '/usr/bin/ffmpeg';
   const args = [
     '-y',
     '-i', `${directory}/${basename}%0${IMAGE_DIGITS}d.${CAPTURE_OPTIONS.format}`,

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ const stop = async () => {
   }
 
   // Create a mp4 movie out of the image frames.
-  const cmd = '/usr/bin/ffmpeg';
+  const cmd = 'ffmpeg';
   const args = [
     '-y',
     '-i', `${directory}/${basename}%0${IMAGE_DIGITS}d.${CAPTURE_OPTIONS.format}`,


### PR DESCRIPTION
Most common path for `ffmpeg` is `/usr/bin/ffmpeg` instead of `/usr/local/bin/ffmpeg` but decided to remove path altogether.