### PR TITLE
fix: clear out frame buffer after saving frames into screenshot files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,9 @@ const stop = async () => {
     }
   }
 
+  // Clear out the frame buffer.
+  plugin.frames = [];
+
   // Create a mp4 movie out of the image frames.
   const cmd = 'ffmpeg';
   const args = [


### PR DESCRIPTION
Problem: each subsequent call of recording adds the previous video to the beginning of the next.